### PR TITLE
Implemented Pageant named pipe proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ go build -ldflags -H=windowsgui
 
 
 ## Usage
-Run the executable `winssh-pageant.exe`. There is only one (optional) flag:
+Run the executable `winssh-pageant.exe`. There are two (optional) flags:
 
  - `--sshpipe` - name of the windows openssh agent pipe, default is `"\\.\pipe\ssh-pageant"`
+ - `--no-pageant-pipe` - disable pageant named pipe proxying
 
 
 ### Task Scheduler

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.14
 require (
 	github.com/Microsoft/go-winio v0.4.14
 	github.com/lxn/win v0.0.0-20191128105842-2da648fda5b4
-	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
+	golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3
 )

--- a/go.sum
+++ b/go.sum
@@ -14,3 +14,5 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3 h1:qDJKu1y/1SjhWac4BQZjLljqvqiWUhjmDMnonmVGDAU=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/sshagent/agent.go
+++ b/internal/sshagent/agent.go
@@ -7,9 +7,13 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
+const (
+	AgentMaxMessageLength = 1<<14 - 1
+)
+
 // QueryAgent provides a way to query the named windows openssh agent pipe
-func QueryAgent(pipeName string, buf []byte, agentMaxMessageLength int) (result []byte, err error) {
-	if len(buf) > agentMaxMessageLength {
+func QueryAgent(pipeName string, buf []byte) (result []byte, err error) {
+	if len(buf) > AgentMaxMessageLength {
 		return nil, fmt.Errorf("Message too long")
 	}
 
@@ -25,7 +29,7 @@ func QueryAgent(pipeName string, buf []byte, agentMaxMessageLength int) (result 
 	}
 
 	reader := bufio.NewReader(conn)
-	res := make([]byte, agentMaxMessageLength)
+	res := make([]byte, AgentMaxMessageLength)
 
 	l, err = reader.Read(res)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/sha256"
 	"flag"
 	"fmt"
 
@@ -12,22 +11,11 @@ var (
 	sshPipe = flag.String("sshpipe", `\\.\pipe\openssh-ssh-agent`, "Named pipe for Windows OpenSSH agent")
 )
 
-// var testPipeName = `\\.\pipe\pageant.Nate.de663e60ca4268cef1d1f931f1d8ffe2d0df1de50aa09d8cc29facc5991d3638`
-var testPipeName = `\\.\pipe\pageant.Nate`
-
 func main() {
 	flag.Parse()
 
-	fmt.Println(fmt.Sprintf(`terst\%s.%s`, "Nate", "sha"))
-	fmt.Println("open serv")
+	// Start a proxy/redirector for the pageant named pipes
 	go pipeProxy()
-	fmt.Println("postopen serv")
-
-	fmt.Println("wait rec:")
-	// fmt.Println(<-ch)
-
-	sum := sha256.Sum256([]byte(`Pageant`))
-	fmt.Printf("%x", sum)
 
 	pageantWindow := createPageantWindow()
 	if pageantWindow == 0 {

--- a/main.go
+++ b/main.go
@@ -8,14 +8,17 @@ import (
 )
 
 var (
-	sshPipe = flag.String("sshpipe", `\\.\pipe\openssh-ssh-agent`, "Named pipe for Windows OpenSSH agent")
+	sshPipe       = flag.String("sshpipe", `\\.\pipe\openssh-ssh-agent`, "Named pipe for Windows OpenSSH agent")
+	noPageantPipe = flag.Bool("no-pageant-pipe", false, "Toggle pageant named pipe proxying")
 )
 
 func main() {
 	flag.Parse()
 
 	// Start a proxy/redirector for the pageant named pipes
-	go pipeProxy()
+	if !*noPageantPipe {
+		go pipeProxy()
+	}
 
 	pageantWindow := createPageantWindow()
 	if pageantWindow == 0 {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
 	"flag"
 	"fmt"
-	"syscall"
 
 	"github.com/lxn/win"
 )
@@ -12,27 +12,24 @@ var (
 	sshPipe = flag.String("sshpipe", `\\.\pipe\openssh-ssh-agent`, "Named pipe for Windows OpenSSH agent")
 )
 
+// var testPipeName = `\\.\pipe\pageant.Nate.de663e60ca4268cef1d1f931f1d8ffe2d0df1de50aa09d8cc29facc5991d3638`
+var testPipeName = `\\.\pipe\pageant.Nate`
+
 func main() {
 	flag.Parse()
 
-	inst := win.GetModuleHandle(nil)
-	atom := registerPageantWindow(inst)
-	if atom == 0 {
-		fmt.Println(fmt.Errorf("RegisterClass failed: %d", win.GetLastError()))
-		return
-	}
+	fmt.Println(fmt.Sprintf(`terst\%s.%s`, "Nate", "sha"))
+	fmt.Println("open serv")
+	go pipeProxy()
+	fmt.Println("postopen serv")
 
-	// CreateWindowEx
-	pageantWindow := win.CreateWindowEx(win.WS_EX_APPWINDOW,
-		syscall.StringToUTF16Ptr(wndClassName),
-		syscall.StringToUTF16Ptr(wndClassName),
-		0,
-		0, 0,
-		0, 0,
-		0,
-		0,
-		inst,
-		nil)
+	fmt.Println("wait rec:")
+	// fmt.Println(<-ch)
+
+	sum := sha256.Sum256([]byte(`Pageant`))
+	fmt.Printf("%x", sum)
+
+	pageantWindow := createPageantWindow()
 	if pageantWindow == 0 {
 		fmt.Println(fmt.Errorf("CreateWindowEx failed: %v", win.GetLastError()))
 		return

--- a/pageant.go
+++ b/pageant.go
@@ -1,11 +1,20 @@
 package main
 
 import (
+	"bufio"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os/user"
+	"strings"
 	"syscall"
 	"unsafe"
 
 	"encoding/binary"
 
+	"github.com/Microsoft/go-winio"
 	"github.com/lxn/win"
 	"golang.org/x/sys/windows"
 
@@ -23,9 +32,9 @@ const (
 	FILE_MAP_ALL_ACCESS = 0xf001f
 
 	// Pageant consts
-	agentMaxMessageLength = 1<<14 - 1
-	agentCopyDataID       = 0x804e50ba
-	wndClassName          = "Pageant"
+	agentPipeName   = `\\.\pipe\pageant.%s.%x`
+	agentCopyDataID = 0x804e50ba
+	wndClassName    = "Pageant"
 )
 
 // copyDataStruct is used to pass data in the WM_COPYDATA message.
@@ -53,6 +62,29 @@ func registerPageantWindow(hInstance win.HINSTANCE) (atom win.ATOM) {
 	wc.HIconSm = win.LoadIcon(0, win.MAKEINTRESOURCE(win.IDI_APPLICATION))
 
 	return win.RegisterClassEx(&wc)
+}
+
+func createPageantWindow() win.HWND {
+	inst := win.GetModuleHandle(nil)
+	atom := registerPageantWindow(inst)
+	if atom == 0 {
+		fmt.Println(fmt.Errorf("RegisterClass failed: %d", win.GetLastError()))
+		return 0
+	}
+
+	// CreateWindowEx
+	pageantWindow := win.CreateWindowEx(win.WS_EX_APPWINDOW,
+		syscall.StringToUTF16Ptr(wndClassName),
+		syscall.StringToUTF16Ptr(wndClassName),
+		0,
+		0, 0,
+		0, 0,
+		0,
+		0,
+		inst,
+		nil)
+
+	return pageantWindow
 }
 
 func openFileMap(dwDesiredAccess uint32, bInheritHandle uint32, mapNamePtr uintptr) (windows.Handle, error) {
@@ -98,15 +130,16 @@ func wndProc(hWnd win.HWND, message uint32, wParam uintptr, lParam uintptr) uint
 			}
 			defer windows.UnmapViewOfFile(sharedMemory)
 
-			sharedMemoryArray := (*[agentMaxMessageLength]byte)(unsafe.Pointer(sharedMemory))
+			sharedMemoryArray := (*[sshagent.AgentMaxMessageLength]byte)(unsafe.Pointer(sharedMemory))
 
 			size := binary.BigEndian.Uint32(sharedMemoryArray[:4]) + 4
 			// size += 4
-			if size > agentMaxMessageLength {
+			if size > sshagent.AgentMaxMessageLength {
 				return 0
 			}
 
-			result, err := sshagent.QueryAgent(*sshPipe, sharedMemoryArray[:size], agentMaxMessageLength)
+			// result, err := sshagent.QueryAgent(*sshPipe, sharedMemoryArray[:size], sshagent.AgentMaxMessageLength)
+			result, err := sshagent.QueryAgent(*sshPipe, sharedMemoryArray[:size])
 			copy(sharedMemoryArray[:], result)
 			// success
 			return 1
@@ -114,4 +147,67 @@ func wndProc(hWnd win.HWND, message uint32, wParam uintptr, lParam uintptr) uint
 	}
 
 	return win.DefWindowProc(hWnd, message, wParam, lParam)
+}
+
+func pipeProxy() {
+	currentUser, err := user.Current()
+	pipeName := fmt.Sprintf(agentPipeName, strings.Split(currentUser.Username, `\`)[1], sha256.Sum256([]byte(wndClassName)))
+	listener, err := winio.ListenPipe(pipeName, nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		go pipeListen(conn)
+	}
+}
+
+func pipeListen(pageantConn net.Conn) {
+	defer pageantConn.Close()
+	reader := bufio.NewReader(pageantConn)
+
+	for {
+		lenBuf := make([]byte, 4)
+		_, err := io.ReadFull(reader, lenBuf)
+		if err != nil {
+			// if *verbose {
+			// 	log.Printf("io.ReadFull error '%s'", err)
+			// }
+			return
+		}
+
+		bufferLen := binary.BigEndian.Uint32(lenBuf)
+		readBuf := make([]byte, bufferLen)
+		_, err = io.ReadFull(reader, readBuf)
+		if err != nil {
+			// if *verbose {
+			// 	log.Printf("io.ReadFull error '%s'", err)
+			// }
+			return
+		}
+
+		result, err := sshagent.QueryAgent(*sshPipe, append(lenBuf, readBuf...))
+		if err != nil {
+			// if *verbose {
+			// 	log.Printf("Pageant query error '%s'", err)
+			// }
+			// result = failureMessage[:]
+		}
+
+		_, err = pageantConn.Write(result)
+		if err != nil {
+			// if *verbose {
+			// 	log.Printf("net.Conn.Write error '%s'", err)
+			// }
+			return
+		}
+	}
 }


### PR DESCRIPTION
As requested in #1, proxying any requests to Pageant named pipes (in the form of  `pageant.<user>.<hash>`) is implemented. 
There is a flag `--no-pageant-pipe` to disable this.