### PR TITLE
Fixes for usage with a Custom agent 

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"unsafe"
 
 	"github.com/lxn/win"
 )
@@ -27,9 +28,11 @@ func main() {
 	}
 
 	// main message loop
-	var msg win.MSG
-	for win.GetMessage(&msg, 0, 0, 0) > 0 {
-		win.TranslateMessage(&msg)
-		win.DispatchMessage(&msg)
+	msg := (*win.MSG)(unsafe.Pointer(win.GlobalAlloc(0, unsafe.Sizeof(win.MSG{}))))
+	defer win.GlobalFree(win.HGLOBAL(unsafe.Pointer(msg)))
+	for win.GetMessage(msg, 0, 0, 0) > 0 {
+		win.TranslateMessage(msg)
+		win.DispatchMessage(msg)
 	}
+
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/lxn/win"
@@ -28,6 +29,7 @@ func main() {
 	}
 
 	// main message loop
+	runtime.LockOSThread()
 	hglobal := win.GlobalAlloc(0, unsafe.Sizeof(win.MSG{}))
 	msg := (*win.MSG)(unsafe.Pointer(hglobal))
 	defer win.GlobalFree(hglobal)

--- a/main.go
+++ b/main.go
@@ -28,8 +28,9 @@ func main() {
 	}
 
 	// main message loop
-	msg := (*win.MSG)(unsafe.Pointer(win.GlobalAlloc(0, unsafe.Sizeof(win.MSG{}))))
-	defer win.GlobalFree(win.HGLOBAL(unsafe.Pointer(msg)))
+	hglobal := win.GlobalAlloc(0, unsafe.Sizeof(win.MSG{}))
+	msg := (*win.MSG)(unsafe.Pointer(hglobal))
+	defer win.GlobalFree(hglobal)
 	for win.GetMessage(msg, 0, 0, 0) > 0 {
 		win.TranslateMessage(msg)
 		win.DispatchMessage(msg)


### PR DESCRIPTION
The purpose of this pull request is to help fix a number of issues when using winssh-pageant with a custom SSH-Agent, such as creating an SSH-Agent using the *golang.org/x/crypto/ssh/agent* library.

## Custom Windows SSH-Agent Deadlock issue

I ran into an issue when using winssh-pageant with a custom SSH-Agent which abruptly would deadlock and crash winssh-pageant, I've detailed the issue at the following link, https://github.com/ndbeals/winssh-pageant/issues/10

The simple solution has been to replace,
https://github.com/ndbeals/winssh-pageant/blob/ff92839d336da9b51525796b80f51ed380176551/main.go#L30-L34
With,
https://github.com/ndbeals/winssh-pageant/blob/fd229a282869b09aabad860d21996bd72314e5b5/main.go#L31-L36

## Bufio Read Issue
A second issue relates to when a PuTTY client makes an initial list query to the SSH-Agent.
This starts with a write operation to the SSH-Agent https://github.com/ndbeals/winssh-pageant/blob/ff92839d336da9b51525796b80f51ed380176551/internal/sshagent/agent.go#L26

This is then followed by a read operation from the SSH-Agent, listing all the keys https://github.com/ndbeals/winssh-pageant/blob/ff92839d336da9b51525796b80f51ed380176551/internal/sshagent/agent.go#L34

The current code relies on all the key data being sent in a single read operation using bufio, however I ran into issues when using this with my custom SSH-Agent, as only the first 4 bytes of data was being returned (I later found out these 4 bytes are magic numbers - I think related to the named pipe).

I did some digging around, and according to the ssh-agent protocol specification ,
https://github.com/openssh/openssh-portable/blob/4e636cf201ce6e7e3b9088568218f9d4e2c51712/PROTOCOL.agent#L379-L387

So I've simply modified the code by breaking it into three distinct read functions, the code is
https://github.com/gazzenger/winssh-pageant/commit/c06f2e864e3088a0b46ff06ea6698a91c8d5cb18#diff-ee5318b37f84592ca501ef36813158b2096992143f93f41eec1b6a0f7205f12cR34-R74 
These three read functions,
- Read the magic number,
- Read the SSH2_AGENT_IDENTITIES_ANSWER,
- Read the number of keys, and
- Read all the key information in a single read operation
This has been tested and works with both my custom SSH-Agent as well as with Windows OpenSSH

Many thanks,
Gary
