### PR TITLE
Do not attempt to read data if no data is left

### DIFF
--- a/openssh/agent.go
+++ b/openssh/agent.go
@@ -66,12 +66,18 @@ func QueryAgent(pipeName string, buf []byte) (result []byte, err error) {
 		return append(messageSizeBuf, replyCode...), nil
 	}
 
+	// replyCode has been read
+	remainingMessageSize := messageSize-1
+
 	// https://datatracker.ietf.org/doc/html/draft-miller-ssh-agent-04#section-3
-	messageContents := make([]byte, messageSize-1)
-	_, err = conn.Read(messageContents)
-	if err != nil {
-		fmt.Printf("cannot read message contents from pipe %s: %s\n", pipeName, err.Error())
-		return append(messageSizeBuf, SSH_AGENT_FAIL), nil
+	messageContents := make([]byte, remainingMessageSize)
+
+	if(remainingMessageSize > 0) {
+		_, err = conn.Read(messageContents)
+		if err != nil {
+			fmt.Printf("cannot read message contents from pipe %s: %s\n", pipeName, err.Error())
+			return append(messageSizeBuf, SSH_AGENT_FAIL), nil
+		}
 	}
 
 	concatResults := append(messageSizeBuf, replyCode...)


### PR DESCRIPTION
This fixes a bug where data is attempted to be read from the ssh-agent pipe, but no data is actually available.

Some background information on how I discovered and fixed this issue:
I am using winssh-pageant in combination with KeePass and KeeAgent.
KeeAgent works in Pageant client mode and adds SSH keys stored in KeePass.
The keys were being added, however it caused KeePass to hang for about 60 seconds, after investigation I found that the code tried to read data, even though no data was available.
I added a check to skip reading data if no more data was available and it works fine for me now.